### PR TITLE
call done after getting profile

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -92,6 +92,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     profile._raw = body;
     profile._json = json;
 
+    done(null, profile);
   });
 };
 


### PR DESCRIPTION
When logging in, it would hang. Upon looking at passport-gitlab, I saw that it calls `done` at the end of `Strategy.prototype.userProfile`.

I haven't checked that it works - I meant to create a PR on my fork. I'll update it if it doesn't work.

Thanks!